### PR TITLE
前月のサマリー結果を LINE に送信する機能を実装した

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Message } from "@/libs/Gmail/01Mail";
 import { PaymentHistory, PaymentHistoryList } from "@/libs/01PaymentHistory";
 import { NoticePaymentHistoryMessage } from "@/libs/Line/03NoticePaymentMessage";
+import { SummaryMessage } from "@/libs/Line/04SummaryMessage";
 import { Line } from "@/libs/Line/01Line";
 import { PaymentHistorySheet } from "@/libs/SpreadSheet/02PaymentHistorySheet";
 
@@ -49,8 +50,16 @@ const main = () => {
     const sheetName = `${targetMonth}月`;
     const sheet = new PaymentHistorySheet(fileName, sheetName);
 
+    const summaryMessage = new SummaryMessage(targetYear, targetMonth);
+    const pushMessage = {
+      type: "flex",
+      altText: "カード利用のお知らせ",
+      contents: summaryMessage.pushMessageContent(),
+    };
+
     sheet.createBarChart(targetMonth);
     sheet.createPieChart(targetMonth);
+    lineClient.pushMessage(pushMessage);
   }
 };
 

--- a/src/libs/Drive/01Drive.ts
+++ b/src/libs/Drive/01Drive.ts
@@ -1,0 +1,58 @@
+/**
+ * Google Drive 操作用クラス
+ */
+export class Drive {
+  /**
+   * フォルダーID を返す
+   * なければ null を返す
+   */
+  private getFolderIdByFolderName(folderName: string): string | null {
+    const folders = DriveApp.getFolders();
+    while (folders.hasNext()) {
+      var folder = folders.next();
+      if (folder.getName() === folderName) {
+        return folder.getId();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * 指定したフォルダ名の folder インスタンスを返す
+   * @param folderName フォルダ名
+   */
+  createDriveFolderByFolderName(folderName: string): GoogleAppsScript.Drive.Folder {
+    const folderId = this.getFolderIdByFolderName(folderName);
+
+    if (folderId === null) {
+      throw new Error("folder id is null!");
+    }
+
+    return DriveApp.getFolderById(folderId);
+  }
+
+  /**
+   * 指定したファイル名の file インスタンスを返す
+   * @param fileName ファイル名
+   */
+  createDriveFileByName(fileName: string): GoogleAppsScript.Drive.File | null {
+    var files = DriveApp.getFilesByName(fileName);
+    if (files.hasNext()) {
+      var file = files.next();
+      return file;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * 指定したフォルダー内のファイルを削除する
+   * 削除するファイルは最初にヒットした１件
+   * @param folderName フォルダー名
+   * @param fileName ファイル名
+   */
+  deleteFile(folderName: string, fileName: string) {
+    const folder = this.createDriveFolderByFolderName(folderName);
+    folder.getFilesByName(fileName).next().setTrashed(true);
+  }
+}

--- a/src/libs/Line/02LineMessage.ts
+++ b/src/libs/Line/02LineMessage.ts
@@ -8,10 +8,13 @@
  *  ※ line-bot-sdk-nodejs を使えば不要になるが、GAS で npm install するには一手間必要なのでここで独自実装している
  */
 
+type Size = number | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "3xl" | "4xl" | "5xl" | "full";
+type Margin = number | "none" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+
 /**
  * Flex メッセージの コンテントの型
  */
-abstract class Content {
+export abstract class Content {
   type: string;
 
   constructor(type: string) {
@@ -20,19 +23,19 @@ abstract class Content {
 }
 
 /**
- * Flex メッセージの Box コンテントの型
+ * Box コンテント作成パラメータ型
  */
 type BoxContentOptions = {
   type?: string;
   layout: string;
   contents?: Content[];
   backgroundColor?: string;
-  margin?: string;
+  margin?: Margin;
   justifyContent?: String;
 };
 
 /**
- * Flex メッセージの メッセージの型
+ * Text コンテント作成パラメータ型
  */
 type TextContentOptions = {
   type?: string;
@@ -41,21 +44,46 @@ type TextContentOptions = {
   align?: string;
   color?: string;
   weight?: string;
-  size?: string;
+  size?: Size;
   flex?: number;
-  margin?: string;
+  margin?: Margin;
+  decoration?: "underline" | "line-through";
 };
 
 /**
- * Flex メッセージの セパレート コンテントの型
+ * Image コンテント作成パラメータ型
+ */
+type ImageContentOptions = {
+  type?: string;
+  url: string;
+  size: Size;
+  margin?: Margin;
+  align?: string;
+};
+
+/**
+ * Flex メッセージの セパレート コンテントクラス
  */
 export class Separator {
   type: string;
-  margin: string;
+  margin: Margin;
 
-  constructor(margin: string) {
+  constructor(margin: Margin) {
     this.type = "separator";
     this.margin = margin;
+  }
+}
+
+/**
+ * Flex メッセージの Filler コンテントクラス
+ */
+export class Filler {
+  type: string;
+  flex?: number;
+
+  constructor(flex?: number) {
+    this.type = "filler";
+    this.flex = flex;
   }
 }
 
@@ -67,7 +95,7 @@ export class BoxContent extends Content {
   layout: string;
   contents?: Content[];
   backgroundColor?: string;
-  margin?: string;
+  margin?: Margin;
   justifyContent?: String;
 
   constructor({ layout, backgroundColor, margin, justifyContent }: BoxContentOptions) {
@@ -100,11 +128,12 @@ export class TextContent extends Content {
   align?: string;
   color?: string;
   weight?: string;
-  size?: string;
+  size?: Size;
   flex?: number;
-  margin?: string;
+  margin?: Margin;
+  decoration?: "underline" | "line-through";
 
-  constructor({ text, wrap = true, align, color, weight, size, flex, margin }: TextContentOptions) {
+  constructor({ text, wrap = true, align, color, weight, size, flex, margin, decoration }: TextContentOptions) {
     super("text");
     this.text = text;
     this.wrap = wrap;
@@ -115,5 +144,26 @@ export class TextContent extends Content {
     if (size) this.size = size;
     if (flex) this.flex = flex;
     if (margin) this.margin = margin;
+    if (decoration) this.margin = margin;
+  }
+}
+
+/**
+ * LINE メッセージの Image 部分をメッセージクラス
+ * https://developers.line.biz/ja/reference/messaging-api/#image-message
+ */
+export class ImageContent extends Content {
+  url: string;
+  size: Size;
+  margin?: Margin;
+  align?: string;
+
+  constructor({ url, size, margin, align }: ImageContentOptions) {
+    super("image");
+    this.url = url;
+    this.size = size;
+
+    if (margin) this.margin = margin;
+    if (align) this.align = align;
   }
 }

--- a/src/libs/Line/04SummaryMessage.ts
+++ b/src/libs/Line/04SummaryMessage.ts
@@ -1,0 +1,260 @@
+import { BoxContent, TextContent, ImageContent, Separator, Filler } from "@/libs/Line/02LineMessage";
+import { PaymentHistorySheet } from "../SpreadSheet/02PaymentHistorySheet";
+import { FixedCostSheet } from "../SpreadSheet/05FixedCostSheet";
+import { PieChartSheet } from "../SpreadSheet/04PieChartSheet";
+
+/**
+ * サマリーメッセージ用クラス
+ */
+export class SummaryMessage {
+  type: string;
+  header: BoxContent;
+  body?: BoxContent;
+  targetYear: string;
+  targetMonth: string;
+
+  constructor(targetYear: string, targetMonth: string) {
+    this.type = "bubble";
+    this.targetYear = targetYear;
+    this.targetMonth = targetMonth;
+    this.header = this.makeHeaderContent();
+    this.body = this.makeBodyContent();
+  }
+
+  /**
+   * 送信メッセージ用のデータを返す
+   */
+  pushMessageContent() {
+    return {
+      type: this.type,
+      header: JSON.parse(JSON.stringify(this.header)),
+      body: JSON.parse(JSON.stringify(this.body)),
+    };
+  }
+
+  /**
+   * 指定した年、月の決済履歴シートクラスをインスタンス化して返す
+   * @param targetYear 対象年
+   * @param targetMonth 対象月
+   */
+  private newPaymentHistorySheet(targetYear: string, targetMonth: string): PaymentHistorySheet {
+    const fileName = `楽天カード決済履歴シート_${targetYear}`;
+    const sheetName = `${targetMonth}月`;
+    return new PaymentHistorySheet(fileName, sheetName);
+  }
+
+  /**
+   * flex メッセージのヘッダーの Box コンテントを作成して返す
+   */
+  makeHeaderContent(): BoxContent {
+    const header = new BoxContent({ layout: "vertical", backgroundColor: "#1E90FF" });
+
+    const headerContent = new TextContent({
+      text: `${this.targetMonth} 月のまとめ💸`,
+      align: "center",
+      color: "#FFFFFFFF",
+      weight: "bold",
+      size: "xl",
+    });
+
+    header.addContent(headerContent);
+
+    return header;
+  }
+
+  /**
+   * flex メッセージのボディの Box コンテントを作成して返す
+   */
+  makeBodyContent(): BoxContent {
+    const bodyContent = new BoxContent({ layout: "vertical" });
+
+    bodyContent.addContent(this.makeSpendingContent());
+    bodyContent.addContent(new Separator("md"));
+    bodyContent.addContent(this.makePreviousMonthAmountComparison());
+    bodyContent.addContent(this.makeFixedCostContent());
+    bodyContent.addContent(new Separator("xl"));
+    bodyContent.addContent(this.makePieChartImageContent());
+
+    return bodyContent;
+  }
+
+  /**
+   * ボディの収支表示用の Box コンテントを作成して返す
+   */
+  makeSpendingContent(): BoxContent {
+    const paymentHistorySheet = this.newPaymentHistorySheet(this.targetYear, this.targetMonth);
+
+    const spendingContent = new BoxContent({ layout: "horizontal" });
+
+    const spendingKey = new TextContent({
+      text: "支出：",
+      weight: "bold",
+      size: "md",
+      flex: 4,
+    });
+
+    const spendingValue = new TextContent({
+      text: `¥ ${paymentHistorySheet.totalAmount().toLocaleString()}`,
+      align: "end",
+      flex: 5,
+      size: "md",
+      weight: "bold",
+      decoration: "underline",
+    });
+
+    spendingContent.addContent(spendingKey);
+    spendingContent.addContent(spendingValue);
+
+    return spendingContent;
+  }
+
+  /**
+   * 前月比を計算して返す
+   * 当月の合計金額 - 前月の合計金額
+   */
+  calcPreviousMonthAmountComparison(): number {
+    const month = Number(this.targetMonth);
+    const previousMonth = month - 1 === 0 ? 12 : month - 1;
+
+    const targetSheet = this.newPaymentHistorySheet(this.targetYear, this.targetMonth);
+
+    const previousSheet = this.newPaymentHistorySheet(this.targetYear, String(previousMonth));
+
+    return targetSheet.totalAmount() - previousSheet.totalAmount();
+  }
+
+  /**
+   * ボディの前月比の Box コンテントを作成して返す
+   */
+  makePreviousMonthAmountComparison(): BoxContent {
+    const amountComparisonContent = new BoxContent({ layout: "horizontal", margin: "md" });
+
+    const filler = new Filler();
+
+    const momKey = new TextContent({
+      text: "前月比",
+      weight: "bold",
+      size: "md",
+      flex: 4,
+    });
+
+    const amountComparison = this.calcPreviousMonthAmountComparison();
+
+    const allow = amountComparison > 0 ? "↑" : "↓";
+    const color = amountComparison > 0 ? "#FF0000" : "#1E90FF";
+
+    const momValue = new TextContent({
+      text: `${allow} ¥ ${amountComparison.toLocaleString()}`,
+      align: "end",
+      flex: 5,
+      size: "md",
+      weight: "bold",
+      color: color,
+    });
+
+    amountComparisonContent.addContent(filler);
+    amountComparisonContent.addContent(momKey);
+    amountComparisonContent.addContent(momValue);
+
+    return amountComparisonContent;
+  }
+
+  /**
+   * 1 レコード分の固定費を表示する Box コンテントを作成して返す
+   * @param isFirstRecord 最初のレコードかどうか
+   * @param costName 固定費名
+   * @param costValue 固定費金額
+   */
+  makeFixedCostContentRecord(isFirstRecord: boolean, costName: string, costValue: number): BoxContent {
+    const fixedCostRecordContent = new BoxContent({
+      layout: "horizontal",
+      margin: "xs",
+      justifyContent: "flex-start",
+    });
+
+    if (isFirstRecord) {
+      const filler = new Filler();
+      const fixedKeyContent = new TextContent({
+        flex: 3,
+        text: "固定費",
+        size: "sm",
+      });
+      fixedCostRecordContent.addContent(filler);
+      fixedCostRecordContent.addContent(fixedKeyContent);
+    } else {
+      const filler = new Filler(4);
+      fixedCostRecordContent.addContent(filler);
+    }
+
+    const nameContent = new TextContent({
+      text: costName,
+      flex: 3,
+      size: "sm",
+    });
+
+    const valueContent = new TextContent({
+      text: `¥ ${costValue.toLocaleString()}`,
+      flex: 3,
+      align: "end",
+    });
+
+    fixedCostRecordContent.addContent(nameContent);
+    fixedCostRecordContent.addContent(valueContent);
+
+    return fixedCostRecordContent;
+  }
+
+  /**
+   * ボディの固定費の Box コンテントを作成して返す
+   */
+  makeFixedCostContent(): BoxContent {
+    const amountComparisonContent = new BoxContent({ layout: "vertical", margin: "sm" });
+
+    //FIXME:　null の時にちゃんとエラーハンドリングする
+    const MASTER_SPREAD_SHEET_FILE =
+      PropertiesService.getScriptProperties().getProperty("MASTER_SPREAD_SHEET_FILE") ?? "";
+
+    const fixedCostSheet = new FixedCostSheet(MASTER_SPREAD_SHEET_FILE, "M_Fixed_cost");
+
+    for (const [index, record] of fixedCostSheet.scanRecord().entries()) {
+      const isFirst = index === 0;
+
+      const costName = record[0];
+      const costValue = record[1];
+
+      if (typeof costName !== "string") {
+        throw new Error("Caught unexpected value!");
+      }
+
+      if (typeof costValue !== "number") {
+        throw new Error("Caught unexpected value!");
+      }
+
+      amountComparisonContent.addContent(this.makeFixedCostContentRecord(isFirst, costName, costValue));
+    }
+
+    return amountComparisonContent;
+  }
+
+  /**
+   * ボディの円グラフの Image コンテントを作成して返す
+   */
+  makePieChartImageContent(): ImageContent {
+    const fileName = `楽天カード決済履歴シート_${this.targetYear}`;
+    const sheetName = `PieChartData-${this.targetMonth}月`;
+
+    const pieChartSheet = new PieChartSheet(fileName, sheetName);
+
+    const chartFileName = `PieChart-${this.targetMonth}`;
+    pieChartSheet.uploadChart(chartFileName);
+    const imageUrl = pieChartSheet.downloadChartUrl(chartFileName);
+
+    const pieChartImageContent = new ImageContent({
+      url: imageUrl,
+      size: "full",
+      align: "center",
+    });
+
+    return pieChartImageContent;
+  }
+}

--- a/src/libs/SpreadSheet/01SpreadSheet.ts
+++ b/src/libs/SpreadSheet/01SpreadSheet.ts
@@ -69,4 +69,28 @@ export class SpreadSheet {
       this.sheet.getRange(1, 1, row, column).setValues(values);
     }
   }
+
+  /**
+   * 対象列の合計を算出して返す
+   * @param rowNumber 開始行番号
+   * @param columnNumber 列番号
+   */
+  sumColumn(startRowNumber: number, columnNumber: number): number {
+    const lastRow = this.sheet.getLastRow();
+
+    //対象列の範囲を取得
+    const range = this.sheet.getRange(startRowNumber, columnNumber, lastRow - 1);
+    const values = range.getValues();
+
+    let totalAmount = 0;
+
+    for (const record of values) {
+      let amount = record[0];
+      if (typeof amount === "number") {
+        totalAmount += amount;
+      }
+    }
+
+    return totalAmount;
+  }
 }

--- a/src/libs/SpreadSheet/02PaymentHistorySheet.ts
+++ b/src/libs/SpreadSheet/02PaymentHistorySheet.ts
@@ -49,6 +49,28 @@ export class PaymentHistorySheet extends SpreadSheet {
   }
 
   /**
+   * 利用金額の合計を算出して返す
+   */
+  totalAmount(): number {
+    const lastRow = this.sheet.getLastRow();
+
+    // 利用金額の列の範囲を取得
+    const range = this.sheet.getRange(2, 4, lastRow - 1);
+    const values = range.getValues();
+
+    let totalAmount = 0;
+
+    for (const record of values) {
+      let amount = record[0];
+      if (typeof amount === "number") {
+        totalAmount += amount;
+      }
+    }
+
+    return totalAmount;
+  }
+
+  /**
    * 指定した 年月の棒グラフ を シートに挿入する
    * @param targetMonth チャート対象の月 (ex. 5月の場合：5, 12 月の場合: 12)
    */

--- a/src/libs/SpreadSheet/02PaymentHistorySheet.ts
+++ b/src/libs/SpreadSheet/02PaymentHistorySheet.ts
@@ -49,28 +49,6 @@ export class PaymentHistorySheet extends SpreadSheet {
   }
 
   /**
-   * 利用金額の合計を算出して返す
-   */
-  totalAmount(): number {
-    const lastRow = this.sheet.getLastRow();
-
-    // 利用金額の列の範囲を取得
-    const range = this.sheet.getRange(2, 4, lastRow - 1);
-    const values = range.getValues();
-
-    let totalAmount = 0;
-
-    for (const record of values) {
-      let amount = record[0];
-      if (typeof amount === "number") {
-        totalAmount += amount;
-      }
-    }
-
-    return totalAmount;
-  }
-
-  /**
    * 指定した 年月の棒グラフ を シートに挿入する
    * @param targetMonth チャート対象の月 (ex. 5月の場合：5, 12 月の場合: 12)
    */

--- a/src/libs/SpreadSheet/04PieChartSheet.ts
+++ b/src/libs/SpreadSheet/04PieChartSheet.ts
@@ -1,0 +1,50 @@
+import { SpreadSheet } from "@/libs/SpreadSheet/01SpreadSheet";
+import { Drive } from "@/libs/Drive/01Drive";
+
+//FIXME: null の場合はちゃんとエラーハンドリングする
+const DRIVE_FOLDER_NAME = PropertiesService.getScriptProperties().getProperty("DRIVE_FOLDER_NAME") ?? "";
+
+/**
+ * 円グラフシート操作用クラス
+ */
+export class PieChartSheet extends SpreadSheet {
+  sheetName: string;
+  constructor(fileName: string, sheetName: string) {
+    super(fileName, sheetName);
+    this.sheetName = sheetName;
+  }
+
+  /**
+   * スプレッドシートのチャートの画像データを取得する
+   */
+  private getChartImg(): GoogleAppsScript.Base.Blob {
+    const graph = this.sheet.getCharts();
+    return graph[0].getBlob();
+  }
+
+  /**
+   * スプレッドシートのチャート画像を ドライブにアップロードする
+   * @param fileName アップロードするファイル名
+   */
+  uploadChart(fileName: string): void {
+    const drive = new Drive();
+    const graphImg = this.getChartImg();
+    const folder = drive.createDriveFolderByFolderName(DRIVE_FOLDER_NAME);
+    folder.createFile(graphImg.setName(fileName));
+  }
+
+  /**
+   * チャートの画像URLをダウンロードする
+   */
+  downloadChartUrl(fileName: string): string {
+    const drive = new Drive();
+    const file = drive.createDriveFileByName(fileName);
+
+    if (file === null) {
+      throw new Error("File does not exist!");
+    }
+    file.setSharing(DriveApp.Access.ANYONE, DriveApp.Permission.VIEW);
+
+    return file.getDownloadUrl();
+  }
+}

--- a/src/libs/SpreadSheet/05FixedCostSheet.ts
+++ b/src/libs/SpreadSheet/05FixedCostSheet.ts
@@ -1,0 +1,23 @@
+import { SpreadSheet } from "@/libs/SpreadSheet/01SpreadSheet";
+
+/**
+ * 固定費シート操作用クラス
+ */
+export class FixedCostSheet extends SpreadSheet {
+  sheetName: string;
+  constructor(fileName: string, sheetName: string) {
+    super(fileName, sheetName);
+    this.sheetName = sheetName;
+  }
+
+  /**
+   * ヘッダーとID を除いた全レコードデータを取得する
+   */
+  scanRecord(): (string | number)[][] {
+    const lastRow = this.sheet.getLastRow();
+
+    // 固定日名と金額の列を取得
+    const range = this.sheet.getRange(2, 2, lastRow - 1, 2);
+    return range.getValues();
+  }
+}


### PR DESCRIPTION
こんな感じで通知される機能を実装した。

<img src="https://github.com/g-kawano/rakuten-card-notice-man/assets/47912388/9a5204e8-6ca5-415d-a538-a43009c3e16b"  width="50%"/>

### 仕組み

1. スプレッドシートにあるチャートの画像バイナリを取得する
2. それを画像ファイルとして Google Drive にアップロードする
3. アップロードした画像の共有URLを取得する
4. サマリーメッセージで画像 URL を使う
5. サマリーメッセージで表示している金額は、楽天決済履歴シートから算出、固定費はマスターシートから取得
6. 決済履歴通知メッセージと同様に、メッセージをプッシュ


### 📝 実装してて気になったこと
- index.ts が肥大化しつつある
- GAS のプロパティー取得用のクラスを作った方が良さそう（python でいう pydantic の setting クラス的なやつ）
- ファイル名やシート名のハードコーディングがちょくちょくある
